### PR TITLE
Get commit SHA from built binary instead of build-time variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,11 @@ COPY . .
 
 # Set build-time variables
 ARG VERSION
-ARG COMMIT
 ARG BUILD_DATE
 
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
   -ldflags "-X github.com/particledecay/slackmoji-notifier/pkg/build.Version=${VERSION} \
-  -X github.com/particledecay/slackmoji-notifier/pkg/build.Commit=${COMMIT} \
   -X github.com/particledecay/slackmoji-notifier/pkg/build.Date=${BUILD_DATE}" \
   -o main .
 


### PR DESCRIPTION
one less build-time variable makes the world a happier place 😃 

## What’s Changed:

* Removed the `COMMIT` argument from the Dockerfile to clean things up.
* Updated `build.go` to automatically fetch the commit SHA, so we automatically always have the latest info.
* Added a couple of helper functions to handle missing values gracefully.

These changes should make the build process easier and ensure that version info is always accurate.