### PR TITLE
build(chart): support for externally managed secret

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: slackmoji-notifier
 description: A channel notifier for new Slack emojis
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "0.2.6"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: slackmoji-notifier
 description: A channel notifier for new Slack emojis
 type: application
 version: 0.4.0
-appVersion: "0.2.6"
+appVersion: "0.4.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               value: {{ .Values.openai.model | default "gpt-3.5-turbo" }}
           envFrom:
             - secretRef:
-                name: {{ include "slackmoji-notifier.fullname" . }}
+                name: {{ .Values.secret.secretName | default (include "slackmoji-notifier.fullname" .) }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +7,7 @@ metadata:
     {{- include "slackmoji-notifier.labels" . | nindent 4 }}
 type: Opaque
 data:
-  SLACK_BOT_TOKEN: {{ .Values.slack.botToken | b64enc }}
-  SLACK_APP_TOKEN: {{ .Values.slack.appToken | b64enc }}
-  OPENAI_API_KEY: {{ .Values.openai.apiKey | b64enc }}
+  SLACK_BOT_TOKEN: {{ .Values.secret.slack.botToken | b64enc }}
+  SLACK_APP_TOKEN: {{ .Values.secret.slack.appToken | b64enc }}
+  OPENAI_API_KEY: {{ .Values.secret.openai.apiKey | b64enc }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: particledecay/slackmoji-notifier
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.6"
+  tag: "0.4.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,7 +25,16 @@ slack:
 
 openai:
   model: "gpt-4o"
-  apiKey: ""
+
+secret:
+  createSecret: true
+  # If specified, use this secret name instead of the generated one
+  secretName: ""
+  slack:
+    botToken: ""
+    appToken: ""
+  openai:
+    apiKey: ""
 
 resources:
   limits:


### PR DESCRIPTION
## What? (description)

Add option to Helm chart to use an externally managed secret.

## Why? (reasoning)

I want to be able to use external secrets to manage my secret from an external source like AWS Secrets Manager rather than have the values passed through chart values. It defaults to the current functionality of creating a secret.

## Screenshots (if applicable)

Confirmed the functionality by installing a release with values:

```
  secret:
    createSecret: false
    secretName: slackmoji-notifier-private
```

And seeing deployment get connected to an external secret:

```
      envFrom:
        - secretRef:
            name: slackmoji-notifier-private
```

## GitHub Issue (if applicable)


## Acceptance
Check your PR for the following:

- [ ] you included tests
- [x] you linted your code
- [x] your PR has appropriate, atomic commits (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [x] you are not reducing the total test coverage
