### PR TITLE
feat: add SLACK_LOG_ONLY option to skip sending message

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,22 @@ For more configuration options, see the [values.yaml](./values.yaml) file.
 5. Give it the background color '#6c5994'
 6. Click "Save Changes"
 7. Click "Socket Mode" in the left sidebar
-8. Click "Enable Socket Mode" and click "Generate" in the popup (this is your `SLACK_APP_TOKEN`)
-9. Click "OAuth & Permissions" in the left sidebar
-10. Under "Bot Token Scopes" click "Add an OAuth Scope" and give it the following:
-    - `channels:read`
-    - `chat:write`
-    - `chat:write.public`
-    - `emoji:read`
-11. Under "OAuth Tokens" click "Install to <Workspace>" and click "Allow"
-12. Copy the "Bot User OAuth Token" (this is your `SLACK_BOT_TOKEN`)
-13. Run the application locally (or within a Kubernetes cluster) and set `SLACK_CHANNEL` to any public channel
+    1. Click "Enable Socket Mode" and click "Generate" in the popup (this is your `SLACK_APP_TOKEN`)
+10. Click "Event Subscriptions" on the resulting page or the left sidebar
+    1. Click "On" to enable
+    2. Click "Subscribe to bot events"
+    3. Click "Add Bot User Event"
+    4. Select "emoji:changed"
+    5. Click "Save Changes" at the bottom
+11. Click "OAuth & Permissions" in the left sidebar
+    1. Under "Bot Token Scopes" click "Add an OAuth Scope" and give it the following:
+        - `channels:read`
+        - `chat:write`
+        - `chat:write.public`
+        - `emoji:read`
+    2. Under "OAuth Tokens" click "Install to <Workspace>" and click "Allow"
+    3. Copy the "Bot User OAuth Token" (this is your `SLACK_BOT_TOKEN`)
+12. Run the application locally (or within a Kubernetes cluster) and set `SLACK_CHANNEL` to any public channel
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Key configuration options:
     - `SLACK_CHANNEL`: The Slack channel where notifications will be sent
     - `SLACK_BOT_TOKEN`: Your Slack Bot Token
     - `SLACK_APP_TOKEN`: Your Slack App Token
+    - `SLACK_LOG_ONLY`: Optional boolean. When true log event instead of sending Slack messages. Useful for debugging and lower environments.
     - `OPENAI_API_KEY`: Your OpenAI API Key
 
 For more configuration options, see the [values.yaml](./values.yaml) file.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: slackmoji-notifier
 description: A channel notifier for new Slack emojis
 type: application
-version: 0.2.6
+version: 0.3.1
 appVersion: "0.2.6"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           env:
             - name: SLACK_CHANNEL
               value: {{ .Values.slack.channel | quote }}
+            - name: SLACK_LOG_ONLY
+              value: {{ .Values.slack.logOnly | default false | quote }}
             - name: OPENAI_MODEL
               value: {{ .Values.openai.model | default "gpt-3.5-turbo" }}
           envFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,6 +21,7 @@ slack:
   channel: "#slackmoji"
   botToken: ""
   appToken: ""
+  # logOnly: true
 
 openai:
   model: "gpt-4o"

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -39,7 +39,7 @@ func runListen(cmd *cobra.Command, args []string) {
 	chatGPTClient := chatgpt.NewClient(cfg.OpenAI.APIKey, cfg.OpenAI.Model, cfg.OpenAI.SystemPrompt)
 	log.Debug().Msg("ChatGPT client initialized")
 
-	n := notifier.New(chatGPTClient)
+	n := notifier.New(chatGPTClient, cfg.Slack.LogOnly)
 	log.Debug().Msg("notifier created")
 
 	debugEventHandler := func(event interface{}) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 )
@@ -18,6 +19,7 @@ type Config struct {
 		BotToken string
 		AppToken string
 		Channel  string
+		LogOnly  bool
 	}
 	OpenAI struct {
 		APIKey       string
@@ -33,6 +35,12 @@ func New() *Config {
 	config.Slack.BotToken = os.Getenv("SLACK_BOT_TOKEN")
 	config.Slack.AppToken = os.Getenv("SLACK_APP_TOKEN")
 	config.Slack.Channel = os.Getenv("SLACK_CHANNEL")
+	logOnlyValue := os.Getenv("SLACK_LOG_ONLY")
+	if logOnlyValue == "" {
+		logOnlyValue = "false"
+	}
+	logOnly, _ := strconv.ParseBool(logOnlyValue)
+	config.Slack.LogOnly = logOnly
 
 	log.Debug().Msg("setting OpenAI configuration")
 	config.OpenAI.APIKey = os.Getenv("OPENAI_API_KEY")


### PR DESCRIPTION
feat: add SLACK_LOG_ONLY option to skip sending message

## What? (description)

Add optional environment variable `SLACK_LOG_ONLY`. When this is set to true emoji add events are logged but not sent to Slack.

Also adds Slack event configuration needed to `README.md` documentation.

## Why? (reasoning)

This can be useful for debugging or running in lower environments where you don't want to run the app but not generate actual messages.

## Screenshots (if applicable)

With `SLACK_LOG_ONLY="true"` 

![image](https://github.com/user-attachments/assets/883cf274-4a6a-4f86-80c5-5c58455493e7)

## GitHub Issue (if applicable)


## Acceptance
Check your PR for the following:

- [ ] you included tests
- [x] you linted your code
- [x] your PR has appropriate, atomic commits (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage
